### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/js/transformImage/utils/getUniqueId.js
+++ b/src/js/transformImage/utils/getUniqueId.js
@@ -1,4 +1,4 @@
 export const getUniqueId = () =>
     Math.random()
         .toString(36)
-        .substr(2, 9);
+        .slice(2, 11);

--- a/src/js/utils/getFilenameWithoutExtension.js
+++ b/src/js/utils/getFilenameWithoutExtension.js
@@ -1,2 +1,2 @@
 export const getFilenameWithoutExtension = name =>
-    name.substr(0, name.lastIndexOf('.')) || name;
+    name.substring(0, name.lastIndexOf('.')) || name;


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.