### PR TITLE
fix(type): requestPrepare return type is a blob with a name or a file

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,7 +3,7 @@ import { FilePondOptions, FilePondFile } from 'filepond';
 
 declare module 'filepond' {
     export interface FilePondFile {
-        requestPrepare: () => Promise<Blob>;
+        requestPrepare: () => Promise<(Blob & {name: string}) | File>;
     }
 
     export interface FilePondOptions {


### PR DESCRIPTION
As demonstrated by this console.log with an image and with a pdf

![image](https://user-images.githubusercontent.com/6115458/168691089-aa2b028e-360c-4683-84a0-1afe1773b98e.png)
